### PR TITLE
feat(publish-release): add output to job 

### DIFF
--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -144,3 +144,7 @@ jobs:
                 }
               ]
             }
+
+      - name: Debugging job output
+        run: |
+          echo "${{ steps.changesets.outputs.published }}"

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -43,6 +43,8 @@ jobs:
       packages: write
       pull-requests: write
     runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -148,7 +148,3 @@ jobs:
                 }
               ]
             }
-
-      - name: Debugging job output
-        run: |
-          echo "${{ steps.changesets.outputs.published }}"

--- a/.github/workflows/publish-releases.yml
+++ b/.github/workflows/publish-releases.yml
@@ -32,6 +32,10 @@ on:
         required: false
       changeset-github-token:
         required: true
+    outputs:
+      published:
+        description: "Whether a new release was published or not"
+        value: ${{ jobs.changeset-releases.outputs.published }}
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This enables users of the workflow to chain other jobs conditionally.

The specific use case for this is in our Zapier integration. We use
publish-release workflow to manage a GitHub release and changelog and if the job
succeeds and has published a package, we want to trigger a Zapier deployment.

Can be seen in action here: https://github.com/understory-io/api-integration-zapier/blob/main/.github/workflows/release-packages.yml#L18-L20