### PR TITLE
feat: use node 22 for glue workflow

### DIFF
--- a/.github/workflows/glue.yml
+++ b/.github/workflows/glue.yml
@@ -69,7 +69,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          node-version: 18
+          node-version: 22
           registry-url: "https://npm.pkg.github.com"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"


### PR DESCRIPTION
Since we want to bump our node16 lambdas to node22 anyway, we should also run our installation, tests, etc, on node 22 as well. I am not entirely sure if something can break so will test out on api-links before merging