### PR TITLE
feat(ci-go-lib): add AWS test creds to test step

### DIFF
--- a/.github/workflows/ci-go-library.yml
+++ b/.github/workflows/ci-go-library.yml
@@ -47,6 +47,9 @@ jobs:
 
       - name: Test
         run: make test
+        env:
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
 
         # experimental improved cache strategy
       - name: Trim Go cache


### PR DESCRIPTION
Add AWS test credentials by default to the environment of the test step to allow localstack/AWS SDKs to work seamlessly.